### PR TITLE
Update dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,8 +7,13 @@ RUN sudo apt-get install -y build-essential curl libffi-dev libffi7 libgmp-dev l
 # We use the official instalation script
 RUN sudo curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-# Add ghcup to path
+# Env variables:
+#   - Adds ghcup binaries to path
+#   - set ghcup instalation script to non-interactive
+#   - set ghcup instalation script to minimal instalation. That is: just install ghcup and nothing else
 ENV PATH=${PATH}:${HOME}/.ghcup/bin
+ENV BOOTSTRAP_HASKELL_NONINTERACTIVE=true
+ENV BOOTSTRAP_HASKELL_MINIMAL=true
 
 # Set up the environment. This will install the default versions of every tool.
 RUN ghcup install ghc
@@ -22,25 +27,3 @@ RUN ghcup install cabal
 # WARNING! Maybe this is not adecuate for your project! use your project wise stack.yaml to change this
 RUN stack config set install-ghc --global false
 RUN stack config set system-ghc --global true 
-
-# If you want to use your own cabal / stack file delete from here to the end of the file
-# ********* DELETE FROM HERE **********
-#  v v v v v v v v v v v v v v v v v v 
-
-# Generate the right cabal file. Using cabal init after ghc installation ensures that the right version of base is used
-# Otherwise, the template would become deprecated as long as ghcup decides to pick up a different version of ghc.
-RUN cabal init \
-    --license=MIT \
-    --homepage=https://github.com/gitpod-io/template-haskell \
-    --author=Gitpod \
-    --category=Example \
-    --email=contact@gitpod.io \
-    --package-name=gitpod-template \
-    --synopsis="See README for more info" \
-    --libandexe \
-    --tests \
-    --test-dir=test \
-    --overwrite
-
-# similarly, running stack init --force after cabal init, ensures that stack will chose a snapshot compatible with system's ghc
-RUN stack init --force

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,21 @@
 image:
   file: .gitpod.Dockerfile
 tasks:
-  - init:
-      stack build
+  - command:
+      cabal init
+        --license=MIT
+        --homepage=https://github.com/gitpod-io/template-haskell
+        --author=Gitpod
+        --category=Example
+        --email=contact@gitpod.io
+        --package-name=gitpod-template
+        --synopsis="See README for more info"
+        --libandexe
+        --tests
+        --test-dir=test
+        --overwrite
+      && stack init --force
+      && stack build
 vscode:
   extensions:
     - haskell.haskell

--- a/README.md
+++ b/README.md
@@ -18,8 +18,5 @@ Click the above "Open in Gitpod" button to start a new workspace. Once you're re
 
 If you have an existing project and you want to create a gitpod environment for it, you need to follow and take into account these considerations.
 
-- This repo's Dockerfile **completely overwrites** the `cabal` and `stack` files when building the container. This means, that if you simply copy-paste the `.gitpod.Dockerfile`, your `cabal`/`stack` files will disappear. Follow the instructions within `.gitpod.Dockerfile` to change this behaviour.
+- For maintainability reasons, the field `tasks.command` in the `.gitpod.yaml` is configured to **completely overwrites** the `.cabal` and `stack.yaml` files. This is likely not what you want, since all dependencies will be lost. Please, configure `task.command` with your build preferences.
 - This repo uses `ghcup` to install all the tooling. Alternative installation isn't recommended.
-- If you are using `stack` it is **highly** recommended to disallow it from installing `ghc` on its own. Otherwise, you'll encounter problems when integrating with `haskell-language-protocol`. To configure `stack` properly, run the following:
-  - `stack config set install-ghc --global false`
-  - `stack config set system-ghc --global true`


### PR DESCRIPTION
This PR fixes a few issues with the current docker file.

- First: ghcup runs in interactive mode, so it fails to install the tools. Apparently this wasn't an issue a few months ago, but it is now. 
- The `cabal` and `stack` commands should be run after building the container not while building it. That's why I've moved them to `.gitpod.yaml`

